### PR TITLE
add the ability to assume an IAM role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>simpleclient_servlet</artifactId>
 		</dependency>

--- a/src/main/java/org/jmal98/metrics/collector/Sqs.java
+++ b/src/main/java/org/jmal98/metrics/collector/Sqs.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
@@ -42,11 +43,13 @@ public class Sqs extends Collector {
 				if (queueEndpoint != null) {
 					sqs = AmazonSQSClientBuilder
 						.standard()
+						.withCredentials(WebIdentityTokenCredentialsProvider.create())
 						.withEndpointConfiguration(new EndpointConfiguration(queueEndpoint, region))
 					.build();
 				} else {
 					sqs = AmazonSQSClientBuilder
 						.standard()
+						.withCredentials(WebIdentityTokenCredentialsProvider.create())
 						.withRegion(region)
 					.build();
 				}


### PR DESCRIPTION
The SQS Client used is missing `WebIdentityTokenCredentialsProvider` in the auth chain - so the app was unable to assume a role from a service account (IRSA) -> https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html .  This change allows us to use assume the role.

Note, if we want this change to merge into the upstream branch, we need to test the other methods of auth that are also supported, as I assume this breaks those options.