### PR TITLE
GLOB-78903: Update Alpine base image to 3.21.3 for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.21.3
 
 RUN apk add --no-cache openjdk8-jre
 


### PR DESCRIPTION
This PR updates the Alpine base image from 3.15.0 to 3.21.3 to address security vulnerabilities. The update includes various security fixes and improvements in the Alpine Linux distribution.